### PR TITLE
fix: Extend user_config.mappings

### DIFF
--- a/lua/nvim-navbuddy/init.lua
+++ b/lua/nvim-navbuddy/init.lua
@@ -290,6 +290,10 @@ function M.setup(user_config)
 			end
 		end
 
+		if user_config.mappings ~= nil then
+			config.mappings = vim.tbl_deep_extend("keep", user_config.mappings, config.mappings)
+		end
+
 		if user_config.lsp ~= nil then
 			config.lsp = vim.tbl_deep_extend("keep", user_config.lsp, config.lsp)
 		end


### PR DESCRIPTION
Hello, it seems this missing from the setup function to allow custom config mappings. Addresses #6. My apologies if I misunderstood your intentions and thanks for the plugin!