### PR TITLE
Push old cursor position to jumplist on select

### DIFF
--- a/lua/nvim-navbuddy/actions.lua
+++ b/lua/nvim-navbuddy/actions.lua
@@ -63,9 +63,11 @@ end
 function actions.select(display)
 	display:close()
 	-- to push location to jumplist:
-	-- move display to start_cursor, then move to new position using G
+	-- move display to start_cursor, set mark ', then move to new location
 	vim.api.nvim_win_set_cursor(display.for_win, display.start_cursor)
-	vim.api.nvim_command(string.format("normal! %dG%d|", display.focus_node.name_range["start"].line, display.focus_node.name_range["start"].character))
+	vim.api.nvim_command("normal! m'")
+	vim.api.nvim_win_set_cursor(display.for_win, {display.focus_node.name_range["start"].line,
+												  display.focus_node.name_range["start"].character})
 end
 
 function actions.yank_name(display)


### PR DESCRIPTION
After selecting a node, I expect to be able to navigate back to my original position using `<C-o>` to move backwards in the jump list. However, `nvim_win_set_cursor()` does not add to the jumplist.

Instead, I set cursor to the start position, then navigate to the new position using a G command, which does add to the jumplist. Because the second action happens immediately, I don't see a visual artifact from jumping to the old position.

Now `<C-o>` and `<C-i>` work as expected.

Relevant stackoverflow: https://stackoverflow.com/questions/19195160/push-a-location-to-the-jumplist
I experimented with setting a mark with ``normal! m` ``, but it didn't seem to work.