### PR TITLE
feat: Use v:count1 for previous/next_sibling actions

### DIFF
--- a/lua/nvim-navbuddy/actions.lua
+++ b/lua/nvim-navbuddy/actions.lua
@@ -10,8 +10,13 @@ function actions.next_sibling(display)
 		return
 	end
 
-	local next_node = display.focus_node.next
-	display.focus_node = next_node
+	for _ = 1, vim.v.count1 do
+		local next_node = display.focus_node.next
+		if next_node == nil then
+			break
+		end
+		display.focus_node = next_node
+	end
 
 	display:redraw()
 end
@@ -21,8 +26,13 @@ function actions.previous_sibling(display)
 		return
 	end
 
-	local prev_node = display.focus_node.prev
-	display.focus_node = prev_node
+	for _ = 1, vim.v.count1 do
+		local prev_node = display.focus_node.prev
+		if prev_node == nil then
+			break
+		end
+		display.focus_node = prev_node
+	end
 
 	display:redraw()
 end


### PR DESCRIPTION
Adds support for using a count with `actions.next_sibling` and `actions.previous_sibling`. For example, `5j` moves down by 5 nodes.

Because `v:count1 == 1` when no count is provided, `j` and `k` work as expected, even if used without a count.