### PR TITLE
feat: Add root node action

### DIFF
--- a/doc/navbuddy.txt
+++ b/doc/navbuddy.txt
@@ -163,6 +163,7 @@ Defaults >
 
 			["h"] = actions.parent,           -- Move to left panel
 			["l"] = actions.children,         -- Move to right panel
+			["0"] = actions.root,             -- Move to first panel
 
 			["v"] = actions.visual_name,      -- Visual selection of name
 			["V"] = actions.visual_scope,     -- Visual selection of scope
@@ -219,6 +220,9 @@ Actions                                                         *navbuddy-action
 
 *actions.children* (opts)
 	Move to children of current, right of current node, in Navbuddy window.
+
+*actions.root* (opts)
+	Move to root node, the first node left of current node, in Navbuddy window.
 
 *actions.select* (opts)
 	Goto currently focus node.

--- a/lua/nvim-navbuddy/actions.lua
+++ b/lua/nvim-navbuddy/actions.lua
@@ -55,6 +55,18 @@ function actions.children(display)
 	display:redraw()
 end
 
+function actions.root(display)
+	if display.focus_node.parent.is_root then
+		return
+	end
+
+	while not display.focus_node.parent.is_root do
+		display.focus_node = display.focus_node.parent
+	end
+
+	display:redraw()
+end
+
 function actions.select(display)
 	display:close()
 	-- to push location to jumplist:

--- a/lua/nvim-navbuddy/init.lua
+++ b/lua/nvim-navbuddy/init.lua
@@ -60,6 +60,7 @@ local config = {
 
 		["h"] = actions.parent,
 		["l"] = actions.children,
+		["0"] = actions.root,
 
 		["v"] = actions.visual_name,
 		["V"] = actions.visual_scope,


### PR DESCRIPTION
Adds an action to move back to the root level of the tree. Analogous to Vim's `0` key to go to the beginning of the line, the default mapping for this action is `0`.

Navbuddy remembers the last open branches of each level, so it is possible to move back to the last position after hitting `0` by pressing `l` multiple times.