### PR TITLE
fix: Set parent node's memory in actions.root

### DIFF
--- a/lua/nvim-navbuddy/actions.lua
+++ b/lua/nvim-navbuddy/actions.lua
@@ -71,6 +71,7 @@ function actions.root(display)
 	end
 
 	while not display.focus_node.parent.is_root do
+		display.focus_node.parent.memory = display.focus_node.index
 		display.focus_node = display.focus_node.parent
 	end
 


### PR DESCRIPTION
I thought the trail to the last node was remembered when running `actions.root` (#32), but actually, each parent's memory index was set to 1. 

This PR fixes that issue by setting the each parent's memory to `focus_node.index`, the same as if `h` was pressed repeatedly to reach the root.