### PR TITLE
feat: Add NavbuddyNormalFloat highlight group

### DIFF
--- a/doc/navbuddy.txt
+++ b/doc/navbuddy.txt
@@ -285,7 +285,7 @@ available.
 	`NavbuddyName`  - highlight for name in source buffer
 	`NavbuddyScope` - highlight for scope of context in source buffer
 	`NavbuddyFloatBorder` - Floatborder highlight
-	`NavbuddyNormal` - Float normal highlight
+	`NavbuddyNormalFloat` - Float normal highlight
 
 The following highlights are are used to highlight elements in the navbuddy
 window according to their type. If you have "NavicIcons<type>" highlights

--- a/doc/navbuddy.txt
+++ b/doc/navbuddy.txt
@@ -285,6 +285,7 @@ available.
 	`NavbuddyName`  - highlight for name in source buffer
 	`NavbuddyScope` - highlight for scope of context in source buffer
 	`NavbuddyFloatBorder` - Floatborder highlight
+	`NavbuddyNormal` - Float normal highlight
 
 The following highlights are are used to highlight elements in the navbuddy
 window according to their type. If you have "NavicIcons<type>" highlights

--- a/lua/nvim-navbuddy/display.lua
+++ b/lua/nvim-navbuddy/display.lua
@@ -76,7 +76,7 @@ function display:new(obj)
 		focusable = false,
 		border = config.window.sections.left.border or ui.get_border_chars(config.window.border, "left"),
 		win_options = {
-			winhighlight = "FloatBorder:NavbuddyFloatBorder",
+			winhighlight = "Normal:NavbuddyNormal,FloatBorder:NavbuddyFloatBorder",
 		},
 		buf_options = {
 			modifiable = false,
@@ -87,7 +87,7 @@ function display:new(obj)
 		enter = true,
 		border = config.window.sections.mid.border or ui.get_border_chars(config.window.border, "mid"),
 		win_options = {
-			winhighlight = "FloatBorder:NavbuddyFloatBorder",
+			winhighlight = "Normal:NavbuddyNormal,FloatBorder:NavbuddyFloatBorder",
 			scrolloff = config.window.scrolloff
 		},
 		buf_options = {
@@ -118,7 +118,7 @@ function display:new(obj)
 			text = lsp_name,
 		},
 		win_options = {
-			winhighlight = "FloatBorder:NavbuddyFloatBorder",
+			winhighlight = "Normal:NavbuddyNormal,FloatBorder:NavbuddyFloatBorder",
 			scrolloff = 0,
 		},
 		buf_options = {
@@ -298,6 +298,7 @@ end
 function display:show_preview()
 	vim.api.nvim_win_set_buf(self.right.winid, self.for_buf)
 
+	vim.api.nvim_win_set_option(self.right.winid, 'winhighlight', 'Normal:NavbuddyNormal,FloatBorder:NavbuddyFloatBorder')
 	vim.api.nvim_win_set_option(self.right.winid, "signcolumn", "no")
 	vim.api.nvim_win_set_option(self.right.winid, "foldlevel", 100)
 	vim.api.nvim_win_set_option(self.right.winid, "wrap", false)

--- a/lua/nvim-navbuddy/display.lua
+++ b/lua/nvim-navbuddy/display.lua
@@ -76,7 +76,7 @@ function display:new(obj)
 		focusable = false,
 		border = config.window.sections.left.border or ui.get_border_chars(config.window.border, "left"),
 		win_options = {
-			winhighlight = "Normal:NavbuddyNormal,FloatBorder:NavbuddyFloatBorder",
+			winhighlight = "Normal:NavbuddyNormalFloat,FloatBorder:NavbuddyFloatBorder",
 		},
 		buf_options = {
 			modifiable = false,
@@ -87,7 +87,7 @@ function display:new(obj)
 		enter = true,
 		border = config.window.sections.mid.border or ui.get_border_chars(config.window.border, "mid"),
 		win_options = {
-			winhighlight = "Normal:NavbuddyNormal,FloatBorder:NavbuddyFloatBorder",
+			winhighlight = "Normal:NavbuddyNormalFloat,FloatBorder:NavbuddyFloatBorder",
 			scrolloff = config.window.scrolloff
 		},
 		buf_options = {
@@ -118,7 +118,7 @@ function display:new(obj)
 			text = lsp_name,
 		},
 		win_options = {
-			winhighlight = "Normal:NavbuddyNormal,FloatBorder:NavbuddyFloatBorder",
+			winhighlight = "Normal:NavbuddyNormalFloat,FloatBorder:NavbuddyFloatBorder",
 			scrolloff = 0,
 		},
 		buf_options = {
@@ -298,7 +298,7 @@ end
 function display:show_preview()
 	vim.api.nvim_win_set_buf(self.right.winid, self.for_buf)
 
-	vim.api.nvim_win_set_option(self.right.winid, 'winhighlight', 'Normal:NavbuddyNormal,FloatBorder:NavbuddyFloatBorder')
+	vim.api.nvim_win_set_option(self.right.winid, 'winhighlight', 'Normal:NavbuddyNormalFloat,FloatBorder:NavbuddyFloatBorder')
 	vim.api.nvim_win_set_option(self.right.winid, "signcolumn", "no")
 	vim.api.nvim_win_set_option(self.right.winid, "foldlevel", 100)
 	vim.api.nvim_win_set_option(self.right.winid, "wrap", false)

--- a/lua/nvim-navbuddy/ui.lua
+++ b/lua/nvim-navbuddy/ui.lua
@@ -170,9 +170,9 @@ function ui.highlight_setup()
 		vim.api.nvim_set_hl(0, "NavbuddyFloatBorder", { link = "FloatBorder" })
 	end
 
-	ok, _ = pcall(vim.api.nvim_get_hl_by_name, "NavbuddyNormal", false)
+	ok, _ = pcall(vim.api.nvim_get_hl_by_name, "NavbuddyNormalFloat", false)
 	if not ok then
-		vim.api.nvim_set_hl(0, "NavbuddyNormal", { link = "NormalFloat" })
+		vim.api.nvim_set_hl(0, "NavbuddyNormalFloat", { link = "NormalFloat" })
 	end
 end
 

--- a/lua/nvim-navbuddy/ui.lua
+++ b/lua/nvim-navbuddy/ui.lua
@@ -169,6 +169,11 @@ function ui.highlight_setup()
 	if not ok then
 		vim.api.nvim_set_hl(0, "NavbuddyFloatBorder", { link = "FloatBorder" })
 	end
+
+	ok, _ = pcall(vim.api.nvim_get_hl_by_name, "NavbuddyNormal", false)
+	if not ok then
+		vim.api.nvim_set_hl(0, "NavbuddyNormal", { link = "NormalFloat" })
+	end
 end
 
 return ui


### PR DESCRIPTION
Allows colorschemes to set the Navbuddy popup's background or other Normal highlight options.

Also fixes an issue where the right panel's border highlighting would be reset on showing a preview.