### PR TITLE
feat: Add markers for node type

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ require("lspconfig").clangd.setup {
 Use `setup` to override any of the default options
 
 * `icons` : Indicate the type of symbol captured. Default icons assume you have nerd-fonts.
+* `node_markers` : Indicate whether a node is a leaf or branch node. Default icons assume you have nerd-fonts.
 * `window` : Set options related to window's "border", "size", "position".
 * `use_default_mappings`: If set to false, only mappings set by user are set. Else default mappings are used for keys that are not set by user.
 * `mappings` : Actions to be triggered for specified keybindings. If you wish to set custom keybindings, you will have to set all the keybindings.
@@ -123,8 +124,10 @@ navbuddy.setup {
                                    -- Options: "leaf", "always" or "never"
             }
         },
-        node_markers = {
-            enabled = true,
+    },
+    node_markers = {
+        enabled = true,
+        icons = {
             leaf = "   ",
             leaf_selected = " 󰗼 ",
             branch = "  ",

--- a/README.md
+++ b/README.md
@@ -122,7 +122,12 @@ navbuddy.setup {
                 preview = "leaf",  -- Right section can show previews too.
                                    -- Options: "leaf", "always" or "never"
             }
-        }
+        },
+        node_markers = {
+            leaf = "   ",
+            leaf_selected = " 󰗼 ",
+            branch = "  ",
+        },
     },
     icons = {
         File          = " ",

--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ navbuddy.setup {
             }
         },
         node_markers = {
+            enabled = true,
             leaf = "   ",
             leaf_selected = " 󰗼 ",
             branch = "  ",

--- a/README.md
+++ b/README.md
@@ -128,9 +128,9 @@ navbuddy.setup {
     node_markers = {
         enabled = true,
         icons = {
-            leaf = "   ",
+            leaf = "  ",
             leaf_selected = " 󰗼 ",
-            branch = "  ",
+            branch = " ",
         },
     },
     icons = {

--- a/lua/nvim-navbuddy/display.lua
+++ b/lua/nvim-navbuddy/display.lua
@@ -53,12 +53,12 @@ local function fill_buffer(buf, node, config)
 			0,
 			-1
 		)
-		if config.window.node_markers.enabled then
+		if config.node_markers.enabled then
 			vim.api.nvim_buf_set_extmark(buf.bufnr, ns, i - 1, #lines[i], {
 				virt_text = { {
-					child_node.children ~= nil and config.window.node_markers.branch
-						or i == cursor_pos[1] and config.window.node_markers.leaf_selected
-						or config.window.node_markers.leaf,
+					child_node.children ~= nil and config.node_markers.icons.branch
+						or i == cursor_pos[1] and config.node_markers.icons.leaf_selected
+						or config.node_markers.icons.leaf,
 					i == cursor_pos[1] and { "NavbuddyCursorLine", hl_group } or hl_group,
 				} },
 				virt_text_pos = "right_align",

--- a/lua/nvim-navbuddy/display.lua
+++ b/lua/nvim-navbuddy/display.lua
@@ -53,12 +53,14 @@ local function fill_buffer(buf, node, config)
 			0,
 			-1
 		)
-		if child_node.children ~= nil then
-			vim.api.nvim_buf_set_extmark(buf.bufnr, ns, i - 1, #lines[i], {
-				virt_text = { { " >", i == cursor_pos[1] and { "NavbuddyCursorLine", hl_group } or hl_group } },
-				virt_text_pos = "right_align",
-			})
-		end
+		vim.api.nvim_buf_set_extmark(buf.bufnr, ns, i - 1, #lines[i], {
+			virt_text = { {
+				child_node.children ~= nil and " > " or i == cursor_pos[1] and " 󰗼 " or "   ",
+				i == cursor_pos[1] and { "NavbuddyCursorLine", hl_group } or hl_group,
+			} },
+			virt_text_pos = "right_align",
+			virt_text_hide = false,
+		})
 	end
 
 	vim.api.nvim_buf_add_highlight(buf.bufnr, ns, "NavbuddyCursorLine", cursor_pos[1] - 1, 0, -1)

--- a/lua/nvim-navbuddy/display.lua
+++ b/lua/nvim-navbuddy/display.lua
@@ -53,16 +53,18 @@ local function fill_buffer(buf, node, config)
 			0,
 			-1
 		)
-		vim.api.nvim_buf_set_extmark(buf.bufnr, ns, i - 1, #lines[i], {
-			virt_text = { {
-				child_node.children ~= nil and config.window.markers.branch
-					or i == cursor_pos[1] and config.window.markers.leaf_selected
-					or config.window.markers.leaf,
-				i == cursor_pos[1] and { "NavbuddyCursorLine", hl_group } or hl_group,
-			} },
-			virt_text_pos = "right_align",
-			virt_text_hide = false,
-		})
+		if config.window.node_markers.enabled then
+			vim.api.nvim_buf_set_extmark(buf.bufnr, ns, i - 1, #lines[i], {
+				virt_text = { {
+					child_node.children ~= nil and config.window.node_markers.branch
+						or i == cursor_pos[1] and config.window.node_markers.leaf_selected
+						or config.window.node_markers.leaf,
+					i == cursor_pos[1] and { "NavbuddyCursorLine", hl_group } or hl_group,
+				} },
+				virt_text_pos = "right_align",
+				virt_text_hide = false,
+			})
+		end
 	end
 
 	vim.api.nvim_buf_add_highlight(buf.bufnr, ns, "NavbuddyCursorLine", cursor_pos[1] - 1, 0, -1)

--- a/lua/nvim-navbuddy/display.lua
+++ b/lua/nvim-navbuddy/display.lua
@@ -55,7 +55,9 @@ local function fill_buffer(buf, node, config)
 		)
 		vim.api.nvim_buf_set_extmark(buf.bufnr, ns, i - 1, #lines[i], {
 			virt_text = { {
-				child_node.children ~= nil and " > " or i == cursor_pos[1] and " 󰗼 " or "   ",
+				child_node.children ~= nil and config.window.markers.branch
+					or i == cursor_pos[1] and config.window.markers.leaf_selected
+					or config.window.markers.leaf,
 				i == cursor_pos[1] and { "NavbuddyCursorLine", hl_group } or hl_group,
 			} },
 			virt_text_pos = "right_align",

--- a/lua/nvim-navbuddy/init.lua
+++ b/lua/nvim-navbuddy/init.lua
@@ -22,8 +22,10 @@ local config = {
 				preview = "leaf",
 			},
 		},
-		node_markers = {
-			enabled = true,
+	},
+	node_markers = {
+		enabled = true,
+		icons = {
 			leaf = "   ",
 			leaf_selected = " 󰗼 ",
 			branch = "  ",

--- a/lua/nvim-navbuddy/init.lua
+++ b/lua/nvim-navbuddy/init.lua
@@ -22,6 +22,11 @@ local config = {
 				preview = "leaf",
 			},
 		},
+		node_markers = {
+			leaf = "   ",
+			leaf_selected = " 󰗼 ",
+			branch = "  ",
+		},
 	},
 	icons = {
 		[1] = " ", -- File

--- a/lua/nvim-navbuddy/init.lua
+++ b/lua/nvim-navbuddy/init.lua
@@ -309,6 +309,10 @@ function M.setup(user_config)
 			config.window.sections.right.border = config.window.sections.right.border or "none"
 		end
 
+		if user_config.node_markers ~= nil then
+			config.node_markers = vim.tbl_deep_extend("keep", user_config.node_markers, config.node_markers)
+		end
+
 		if user_config.icons ~= nil then
 			for k, v in pairs(user_config.icons) do
 				if navic.adapt_lsp_str_to_num(k) then

--- a/lua/nvim-navbuddy/init.lua
+++ b/lua/nvim-navbuddy/init.lua
@@ -26,9 +26,9 @@ local config = {
 	node_markers = {
 		enabled = true,
 		icons = {
-			leaf = "   ",
+			leaf = "  ",
 			leaf_selected = " 󰗼 ",
-			branch = "  ",
+			branch = " ",
 		},
 	},
 	icons = {

--- a/lua/nvim-navbuddy/init.lua
+++ b/lua/nvim-navbuddy/init.lua
@@ -23,6 +23,7 @@ local config = {
 			},
 		},
 		node_markers = {
+			enabled = true,
 			leaf = "   ",
 			leaf_selected = " 󰗼 ",
 			branch = "  ",

--- a/lua/nvim-navbuddy/ui.lua
+++ b/lua/nvim-navbuddy/ui.lua
@@ -69,7 +69,7 @@ function ui.get_border_chars(style, section)
 			double  = "╩",
 			solid   = "▙",
 		},
-		blank = " ",
+		blank = "",
 	}
 
 	local border_chars_map = {


### PR DESCRIPTION
This PR adds markers that distinguish leaf/terminal nodes from branch/internal nodes. The markers can be enabled/disabled and their icons changed in a new `node_markers` config section.

It also removes an extra column of whitespace on the right borders of the left and middle popup panes.

## Screenshots
Selecting a branch node:
<img width="839" alt="Screenshot 2023-04-09 at 11 30 06 AM" src="https://user-images.githubusercontent.com/7785912/230781914-e0f3f7e2-ed95-41f2-bc5f-413db556a41c.png">

<details><summary>Showing a preview of a leaf node:</summary>
<p>
<img width="838" alt="Screenshot 2023-04-09 at 11 28 26 AM" src="https://user-images.githubusercontent.com/7785912/230781831-75690812-5d24-4c9d-98fb-62e1c28469ed.png">
</p>
</details> 

<details><summary>Alternate: with space after branch node marker. This takes more space, but the markers are better aligned:</summary>
<p>
<img width="839" alt="Screenshot 2023-04-09 at 11 24 07 AM" src="https://user-images.githubusercontent.com/7785912/230781589-38f51be6-003a-429d-a42a-3a96c7248055.png">
</p>
</details> 

<details><summary>Disabling node markers works as expected (also the selected cursorline on the left and middle panels now extends to the panel border):</summary>
<p>
<img width="840" alt="Screenshot 2023-04-09 at 11 42 35 AM" src="https://user-images.githubusercontent.com/7785912/230782497-eab5856b-1c69-4cbb-9114-da043f90ab1d.png">

</p>
</details> 
