### PR TITLE
fix(telescope): Explicit layout strategy

### DIFF
--- a/lua/nvim-navbuddy/init.lua
+++ b/lua/nvim-navbuddy/init.lua
@@ -102,6 +102,7 @@ local config = {
 		["s"] = actions.toggle_preview,
 
 		["t"] = actions.telescope({
+			layout_strategy = "horizontal",
 			layout_config = {
 				height = 0.60,
 				width = 0.60,


### PR DESCRIPTION
Problem: When user configures Telescope with defaults.layout_strategy = 'flex' or 'vertical', hitting <kbd>t</kbd> in Navbuddy, for the telescope picker, produces error:

> Unsupported layout_config key for the flex strategy: preview_width

Solution: Set layout strategy to `horizontal`.