### PR TITLE
fix(#41): Add nowait=true option on keymap function to suppress operator-pending mode

### DIFF
--- a/lua/nvim-navbuddy/display.lua
+++ b/lua/nvim-navbuddy/display.lua
@@ -236,9 +236,11 @@ function display:new(obj)
 
 	-- Mappings
 	for i, v in pairs(config.mappings) do
-		obj.mid:map("n", i, function()
+		obj.mid:map("n", i,
+        function()
 			v(obj)
-		end)
+		end,
+        { nowait=true })
 	end
 
 	-- Display


### PR DESCRIPTION
Small fix to try to stop operator-pending mode interfering with the plugin mapping.