### PR TITLE
Feature: attach to active clients on setup

### DIFF
--- a/lua/nvim-navbuddy/init.lua
+++ b/lua/nvim-navbuddy/init.lua
@@ -374,6 +374,21 @@ function M.setup(user_config)
 				M.attach(client, bufnr)
 			end,
 		})
+
+		--- Attach to already active clients.
+		local all_clients = vim.lsp.get_active_clients()
+
+		local supported_clients = vim.tbl_filter(function(client)
+			return client.server_capabilities.documentSymbolProvider
+		end, all_clients)
+
+		for _, client in ipairs(supported_clients) do
+			local buffers_of_client = vim.lsp.get_buffers_by_client_id(client.id)
+
+			for _, buffer_number in ipairs(buffers_of_client) do
+				M.attach(client, buffer_number)
+			end
+		end
 	end
 end
 


### PR DESCRIPTION
Closes #66 

This improves the lazy loading capabilities of this plugin. If the user has enabled `auto_attach`, during the setup the plugin will attach itself to all already active clients. This is an addition to the already existing auto-command that will attach to new clients. This allows to source/load the plugin any time and it will work right away having the contact to all clients.

I actually intended to use a dedicated function with a proper name to reduce the complexity of the `setup` function etc. But as this needs to call the "modules" `attach` function and there is the grouping of "private" and "public" methods. So I didn't know where to put it else. 😕 