### PR TITLE
Feature: allow to configure window options as functions

### DIFF
--- a/doc/navbuddy.txt
+++ b/doc/navbuddy.txt
@@ -64,7 +64,7 @@ Use |navbuddy.setup| to override any of the default options
 		have nerd-fonts.
 
 	window: table
-		Set options related to window's "border", "size", "position".
+		Set options related to window's "border", "relative", "size", "position".
 
 	node_markers: table
 		Indicate whether a node is a leaf or branch node. Default icons assume
@@ -112,8 +112,16 @@ Defaults >lua
 			border = "single",  -- "rounded", "double", "solid", "none"
 								-- or an array with eight chars building up the border in a clockwise fashion
 								-- starting with the top-left corner. eg: { "╔", "═" ,"╗", "║", "╝", "═", "╚", "║" }.
+
+			relative = "editor" -- "editor", "cursor", "win", "buf"
+								-- or a function returning a relative value or table (current window as parameter)
+
 			size = "60%",       -- Or table format example: { height = "40%", width = "100%"}
+								-- or a function returning a size value or table (current window as parameter)
+
 			position = "50%",   -- Or table format example: { row = "100%", col = "0%"}
+								-- or a function returning a position value or table (current window as parameter)
+
 			scrolloff = nil,    -- scrolloff value within navbuddy window
 			sections = {
 				left = {

--- a/lua/nvim-navbuddy/actions.lua
+++ b/lua/nvim-navbuddy/actions.lua
@@ -650,12 +650,21 @@ function actions.help()
 	local callback = function(display)
 		display:close()
 
+		local relative = display.config.window.relative
+		relative = type(relative) == "function" and relative(display.for_win) or relative
+
+		local position = display.config.window.position
+		position = type(position) == "function" and position(display.for_win) or position
+
+		local size = display.config.window.size
+		size = type(size) == "function" and size(display.for_win) or size
+
 		local nui_popup = require("nui.popup")
 
 		local help_popup = nui_popup({
-			relative = "editor",
-			position = display.config.window.position,
-			size = display.config.window.size,
+			relative = relative,
+			position = position,
+			size = size,
 			enter = true,
 			focusable = true,
 			border = display.config.window.border,

--- a/lua/nvim-navbuddy/display.lua
+++ b/lua/nvim-navbuddy/display.lua
@@ -142,11 +142,20 @@ function display:new(obj)
 		},
 	})
 
+	local relative = config.window.relative
+	relative = type(relative) == "function" and relative(obj.for_win) or relative
+
+	local position = config.window.position
+	position = type(position) == "function" and position(obj.for_win) or position
+
+	local size = config.window.size
+	size = type(size) == "function" and size(obj.for_win) or size
+
 	local layout = nui_layout(
 		{
-			relative = "editor",
-			position = config.window.position,
-			size = config.window.size,
+			relative = relative,
+			position = position,
+			size = size,
 		},
 		nui_layout.Box({
 			nui_layout.Box(left_popup, { size = config.window.sections.left.size }),

--- a/lua/nvim-navbuddy/init.lua
+++ b/lua/nvim-navbuddy/init.lua
@@ -8,6 +8,7 @@ local actions = require("nvim-navbuddy.actions")
 local config = {
 	window = {
 		border = "single",
+		relative = "editor",
 		size = "60%",
 		position = "50%",
 		scrolloff = nil,


### PR DESCRIPTION
This adds the possibility for more dynamic window configuration. To do so, it allows some window configuration options to be a function. If so, it evaluates the function by calling it with the window number as first parameter. The output of the function is taken as the actual configuration value that is then passed to the Nui library.

In addition to this, it also makes the "relative" option of Nui configurable. The default value reflects the former fixed constant.

A possible usage of this would be a configuration that sizes and positions Navbuddy relative to the current window and with the same width as the window.
Moreover this allows to easily require a minimum width of Navbuddy and much more. It does so without putting the burden to the plugin, but rather the experienced power user.

All changes are fully backwards compatible.