### PR TITLE
Add space after branch icon

### DIFF
--- a/lua/nvim-navbuddy/init.lua
+++ b/lua/nvim-navbuddy/init.lua
@@ -28,7 +28,7 @@ local config = {
 		icons = {
 			leaf = "  ",
 			leaf_selected = " → ",
-			branch = " ",
+			branch = "  ",
 		},
 	},
 	icons = {


### PR DESCRIPTION
The `leaf_selected` icon does this and without it, only half of this double-width character gets highlighted when you select its line. It wastes a tiny bit of horizontal space (that wasn't used by the line selection highlight anyway), but it looks _so_ much better with it.

With the space: 
![image](https://github.com/MartyBeGood/nvim-navbuddy/assets/6429294/1ee0c1aa-26dc-4ccc-afef-404c2dc916b3)
![image](https://github.com/MartyBeGood/nvim-navbuddy/assets/6429294/9367ec8a-b20a-407c-8342-5c74ceaf414e)

Without the space:
![image](https://github.com/MartyBeGood/nvim-navbuddy/assets/6429294/21093ef8-3a5a-4cee-862a-756d8c717583)
![image](https://github.com/MartyBeGood/nvim-navbuddy/assets/6429294/7faa265c-4b44-469d-8bc9-89aed096a1cd)
