### PR TITLE
fix: properly set NavbuddyName highlight

### DIFF
--- a/lua/nvim-navbuddy/display.lua
+++ b/lua/nvim-navbuddy/display.lua
@@ -263,37 +263,17 @@ function display:focus_range()
 	if self.config.source_buffer.highlight then
 		for _, v in ipairs(ranges) do
 			local highlight, range = unpack(v)
-
-			if range["start"].line == range["end"].line then
-				vim.api.nvim_buf_add_highlight(
-					self.for_buf,
-					ns,
-					highlight,
-					range["start"].line - 1,
-					range["start"].character,
-					range["end"].character
-				)
-			else
-				vim.api.nvim_buf_add_highlight(
-					self.for_buf,
-					ns,
-					highlight,
-					range["start"].line - 1,
-					range["start"].character,
-					-1
-				)
-				vim.api.nvim_buf_add_highlight(
-					self.for_buf,
-					ns,
-					highlight,
-					range["end"].line - 1,
-					0,
-					range["end"].character
-				)
-				for i = range["start"].line, range["end"].line - 2, 1 do
-					vim.api.nvim_buf_add_highlight(self.for_buf, ns, highlight, i, 0, -1)
-				end
+			local priority = 100
+			if highlight == "NavbuddyName" then
+				priority = 201
 			end
+
+			vim.api.nvim_buf_set_extmark(self.for_buf, ns, range["start"].line - 1, range["start"].character, {
+				end_row = range["end"].line - 1,
+				end_col = range["end"].character,
+				hl_group = highlight,
+				priority = priority,
+			})
 		end
 	end
 
@@ -358,7 +338,7 @@ function display:hide_preview()
 end
 
 function display:clear_highlights()
-	vim.api.nvim_buf_clear_highlight(self.for_buf, ns, 0, -1)
+	vim.api.nvim_buf_clear_namespace(self.for_buf, ns, 0, -1)
 end
 
 function display:redraw()

--- a/lua/nvim-navbuddy/ui.lua
+++ b/lua/nvim-navbuddy/ui.lua
@@ -174,7 +174,15 @@ function ui.highlight_setup(config)
 
 	ok, _ = pcall(vim.api.nvim_get_hl_by_name, "NavbuddyName", false)
 	if not ok then
-		vim.api.nvim_set_hl(0, "NavbuddyName", { link = "IncSearch" })
+		local ok_normal, normal_hl = pcall(vim.api.nvim_get_hl_by_name, "Normal", true)
+		local normal_bg = ok_normal and normal_hl.background
+
+		local ok_inc, inc_hl = pcall(vim.api.nvim_get_hl_by_name, "IncSearch", true)
+		if ok_inc and inc_hl.background and normal_bg then
+			vim.api.nvim_set_hl(0, "NavbuddyName", { fg = normal_bg, bg = inc_hl.background })
+		else
+			vim.api.nvim_set_hl(0, "NavbuddyName", { link = "IncSearch" })
+		end
 	end
 
 	ok, _ = pcall(vim.api.nvim_get_hl_by_name, "NavbuddyScope", false)


### PR DESCRIPTION
Fixes #83.
ui.lua: sets highlight groups for NavbuddyName based on if IncSearch is set
display.lua: simplified highlight setting, set priority level to override potential treesitter color issues.